### PR TITLE
Add reusable workflow for integration tests

### DIFF
--- a/.github/workflows/integration-template.yml
+++ b/.github/workflows/integration-template.yml
@@ -1,0 +1,42 @@
+name: Integration tests reusable workflow
+on:
+  workflow_call:
+    inputs:
+      sample_name:
+        description: 'The name of the sample app. It MUST be the same name used for the OpenTelemetry Tracer.'
+        required: true
+        type: string
+      sample_path:
+        description: 'The root path of the sample Dockerfile. E.g. ./src/csharp/trace/console'
+        required: true
+        type: string
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Start dependencies
+        run: |
+          docker-compose up -d
+
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.17'
+
+      - name: Build sample Docker image
+        run: docker build -t ${{ inputs.sample_name }} ${{ inputs.sample_path }}
+
+      - name: Run sample app
+        # make sure to use the host network so the container can access the collector on localhost:4317
+        run: docker run --net=host ${{ inputs.sample_name }}
+
+      - name: Test
+        working-directory: ./test/trace
+        run: go test -v -sample=${{ inputs.sample_name }}
+
+      - name: Stop depedencies
+        run: |
+          docker-compose stop


### PR DESCRIPTION
A reusable workflow: https://docs.github.com/en/actions/learn-github-actions/reusing-workflows#creating-a-reusable-workflow that will:

- Start the Collector + Jaeger
- Build the Docker image of the given sample
- Run the sample, which will produce a trace and sent to the collector
- Run a go test (to be added later)