### PR TITLE
Updated container versions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.4"
 services:
   jaeger-otel-recipes:
-    image: jaegertracing/all-in-one:1.28
+    image: jaegertracing/all-in-one:1.29
     ports:
       - "16686:16686"
       - "14268:14268"
@@ -9,7 +9,7 @@ services:
     command: --query.max-clock-skew-adjustment 1s
 
   otel-collector-otel-recipes:
-    image: otel/opentelemetry-collector-contrib:0.38.0
+    image: otel/opentelemetry-collector-contrib:0.40.0
     command: ["--config=/etc/collector-config.yaml", "${OTELCOL_ARGS}"]
     volumes:
       - ./collector-config.yaml:/etc/collector-config.yaml


### PR DESCRIPTION
Just updating the Jaeger and Collector versions.
Quick question, any reason why we are using the `collector-contrib`?
The collector and the collector-contrib are on version 0.41.0, but just the collector has an image uploaded to docker hub.