### PR TITLE
All csharp projects under the same solution

### DIFF
--- a/.github/workflows/csharp-console.yml
+++ b/.github/workflows/csharp-console.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - 'src/csharp/trace/console/**'
+      - 'src/csharp/Recipes.sln'
       - 'test/trace/**'
       - '.github/workflows/integration-template.yml'
       - '.github/workflows/csharp-console.yml'

--- a/src/csharp/Recipes.sln
+++ b/src/csharp/Recipes.sln
@@ -1,0 +1,27 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30114.105
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "trace", "trace", "{A64112D2-3ED5-4607-B98B-3BBA5720B8B9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Console", "trace\console\Console.csproj", "{FDCB4D25-7205-48E8-A814-609753FE09CD}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FDCB4D25-7205-48E8-A814-609753FE09CD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FDCB4D25-7205-48E8-A814-609753FE09CD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FDCB4D25-7205-48E8-A814-609753FE09CD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FDCB4D25-7205-48E8-A814-609753FE09CD}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{FDCB4D25-7205-48E8-A814-609753FE09CD} = {A64112D2-3ED5-4607-B98B-3BBA5720B8B9}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Use a `.sln` file to organize all csharp projects together. Makes viewing them in an IDE easier.