### PR TITLE
Use consistent name of signal folders and ids in schema

### DIFF
--- a/otel-recipes-schema.json
+++ b/otel-recipes-schema.json
@@ -26,7 +26,7 @@
         "id": {
           "type": "string",
           "description": "The unique identifier of the telemetry signal. MUST be one of the suggested by the schema",
-          "enum": ["trace", "metric", "log"]
+          "enum": ["trace", "metrics", "logs"]
         },
         "samples": {
           "type": "array",

--- a/src/site/src/lib/common/types.ts
+++ b/src/site/src/lib/common/types.ts
@@ -59,8 +59,8 @@ export class Signals {
 
 	static readonly all: SignalDropDown[] = [
 		{ id: 'trace', displayName: 'Trace' },
-		{ id: 'metric', displayName: 'Metric' },
-		{ id: 'log', displayName: 'Log' }
+		{ id: 'metrics', displayName: 'Metrics' },
+		{ id: 'logs', displayName: 'Logs' }
 	];
 }
 

--- a/src/site/src/routes/index.svelte
+++ b/src/site/src/routes/index.svelte
@@ -71,7 +71,7 @@
 					>
 						Signal
 					</a>
-					you want to add to your app: Trace, Metric or Log.
+					you want to add to your app: Traces, Metrics or Logs.
 				</p>
 			</div>
 			<div class="column is-4 has-text-centered">


### PR DESCRIPTION
The OTel spec names the folder as `trace`, `metrics` and `logs`. We should follow the same
for our folders where the samples are located. For the website though, we name `Traces` (in plural).

This is in preparation for adding samples for `metrics` and `logs`. It does not affect any of the existing samples.