### PR TITLE
Run api container detached and no need to expose port

### DIFF
--- a/.github/workflows/api-integration-template.yml
+++ b/.github/workflows/api-integration-template.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Run sample app
         # make sure to use the host network so the container can access the collector on localhost:4317
-        run: docker run -p 8080:80 --net=host ${{ inputs.sample_name }} --rm
+        run: docker run -d --net=host ${{ inputs.sample_name }} --rm
 
       - name: Test
         working-directory: ./test/trace


### PR DESCRIPTION
As the container runs in the host network, no need to expose it. The container app needs to run on the port 8080 though.