### PR TITLE
Add recipefile for C# metrics and update site storage

### DIFF
--- a/src/csharp/metrics/recipefile.json
+++ b/src/csharp/metrics/recipefile.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "../../../otel-recipes-schema.json",
+  "languageId": "csharp",
+  "signals": [
+    {
+      "id": "metrics",
+      "samples": [
+        {
+          "id": "csharp-metrics-console",
+          "displayName": "Console App",
+          "description": "A C# console application instrumented with OpenTelemetry that generate metrics.",
+          "sourceRoot": "https://github.com/joaopgrassi/otel-recipes/tree/main/src/csharp/metrics/console",
+          "steps": [
+            {
+              "displayName": "Configure the SDK",
+              "order": 1,
+              "source": "https://raw.githubusercontent.com/joaopgrassi/otel-recipes/main/src/csharp/metrics/console/App.cs"
+            }
+          ],
+          "dependencies": [
+            {
+              "id": "OpenTelemetry",
+              "version": "1.4.0"
+            },
+            {
+              "id": "OpenTelemetry.Exporter.OpenTelemetryProtocol",
+              "version": "1.4.0"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/csharp/trace/recipefile.json
+++ b/src/csharp/trace/recipefile.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../otel-recipes-schema.json",
+  "$schema": "../../../otel-recipes-schema.json",
   "languageId": "csharp",
   "signals": [
     {

--- a/src/site/src/lib/store/data.json
+++ b/src/site/src/lib/store/data.json
@@ -1,6 +1,40 @@
 [
   {
-    "$schema": "../../otel-recipes-schema.json",
+    "$schema": "../../../otel-recipes-schema.json",
+    "languageId": "csharp",
+    "signals": [
+      {
+        "id": "metrics",
+        "samples": [
+          {
+            "id": "csharp-metrics-console",
+            "displayName": "Console App",
+            "description": "A C# console application instrumented with OpenTelemetry that generate metrics.",
+            "sourceRoot": "https://github.com/joaopgrassi/otel-recipes/tree/main/src/csharp/metrics/console",
+            "steps": [
+              {
+                "displayName": "Configure the SDK",
+                "order": 1,
+                "source": "https://raw.githubusercontent.com/joaopgrassi/otel-recipes/main/src/csharp/metrics/console/App.cs"
+              }
+            ],
+            "dependencies": [
+              {
+                "id": "OpenTelemetry",
+                "version": "1.4.0"
+              },
+              {
+                "id": "OpenTelemetry.Exporter.OpenTelemetryProtocol",
+                "version": "1.4.0"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "$schema": "../../../otel-recipes-schema.json",
     "languageId": "csharp",
     "signals": [
       {


### PR DESCRIPTION
Changed where the `recipefile` are located. Each signal folder will have its own, so we don't mix the signals. Also helps in reducing the size of each file. 