### PR TITLE
Prepare for build static site

### DIFF
--- a/src/site/.gitignore
+++ b/src/site/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+/.vscode
 node_modules
 /build
 /.svelte-kit

--- a/src/site/package-lock.json
+++ b/src/site/package-lock.json
@@ -14,10 +14,10 @@
 				"placeholder-loading": "^0.6.0"
 			},
 			"devDependencies": {
-				"@fontsource/fira-mono": "^4.5.10",
 				"@neoconfetti/svelte": "^1.0.0",
 				"@playwright/test": "^1.32.1",
 				"@sveltejs/adapter-auto": "^3.2.0",
+				"@sveltejs/adapter-static": "^3.0.1",
 				"@sveltejs/kit": "^2.5.6",
 				"@sveltejs/vite-plugin-svelte": "^3.1.0",
 				"@types/cookie": "^0.6.0",
@@ -510,12 +510,6 @@
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
-		"node_modules/@fontsource/fira-mono": {
-			"version": "4.5.10",
-			"resolved": "https://registry.npmjs.org/@fontsource/fira-mono/-/fira-mono-4.5.10.tgz",
-			"integrity": "sha512-bxUnRP8xptGRo8YXeY073DSpfK74XpSb0ZyRNpHV9WvLnJ7TwPOjZll8hTMin7zLC6iOp59pDZ8EQDj1gzgAQQ==",
-			"dev": true
-		},
 		"node_modules/@humanwhocodes/config-array": {
 			"version": "0.11.14",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -895,6 +889,15 @@
 			"dependencies": {
 				"import-meta-resolve": "^4.0.0"
 			},
+			"peerDependencies": {
+				"@sveltejs/kit": "^2.0.0"
+			}
+		},
+		"node_modules/@sveltejs/adapter-static": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-3.0.1.tgz",
+			"integrity": "sha512-6lMvf7xYEJ+oGeR5L8DFJJrowkefTK6ZgA4JiMqoClMkKq0s6yvsd3FZfCFvX1fQ0tpCD7fkuRVHsnUVgsHyNg==",
+			"dev": true,
 			"peerDependencies": {
 				"@sveltejs/kit": "^2.0.0"
 			}

--- a/src/site/package.json
+++ b/src/site/package.json
@@ -19,10 +19,10 @@
 		"placeholder-loading": "^0.6.0"
 	},
 	"devDependencies": {
-		"@fontsource/fira-mono": "^4.5.10",
 		"@neoconfetti/svelte": "^1.0.0",
 		"@playwright/test": "^1.32.1",
 		"@sveltejs/adapter-auto": "^3.2.0",
+		"@sveltejs/adapter-static": "^3.0.1",
 		"@sveltejs/kit": "^2.5.6",
 		"@sveltejs/vite-plugin-svelte": "^3.1.0",
 		"@types/cookie": "^0.6.0",

--- a/src/site/src/app.scss
+++ b/src/site/src/app.scss
@@ -20,8 +20,6 @@ $family-primary: $family-serif;
 @import 'bulma/sass/helpers/_all';
 @import 'bulma/sass/layout/_all';
 
-@import '@fontsource/fira-mono';
-
 $ph-bg: $code-bg;
 $ph-border: 0px;
 $ph-color: $grey;

--- a/src/site/src/font.scss
+++ b/src/site/src/font.scss
@@ -4,7 +4,7 @@
   font-family: 'Manrope';
   font-style: normal;
   font-weight: 300;
-  src: url('../fonts/manrope-v15-latin-300.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+  src: url('/fonts/manrope-v15-latin-300.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
 }
 
 /* manrope-regular - latin */
@@ -13,7 +13,7 @@
   font-family: 'Manrope';
   font-style: normal;
   font-weight: 400;
-  src: url('../fonts/manrope-v15-latin-regular.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+  src: url('/fonts/manrope-v15-latin-regular.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
 }
 
 /* manrope-500 - latin */
@@ -22,7 +22,7 @@
   font-family: 'Manrope';
   font-style: normal;
   font-weight: 500;
-  src: url('../fonts/manrope-v15-latin-500.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+  src: url('/fonts/manrope-v15-latin-500.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
 }
 
 /* manrope-600 - latin */
@@ -31,7 +31,7 @@
   font-family: 'Manrope';
   font-style: normal;
   font-weight: 600;
-  src: url('../fonts/manrope-v15-latin-600.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+  src: url('/fonts/manrope-v15-latin-600.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
 }
 
 /* manrope-700 - latin */
@@ -40,5 +40,5 @@
   font-family: 'Manrope';
   font-style: normal;
   font-weight: 700;
-  src: url('../fonts/manrope-v15-latin-700.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
+  src: url('/fonts/manrope-v15-latin-700.woff2') format('woff2'); /* Chrome 36+, Opera 23+, Firefox 39+, Safari 12+, iOS 10+ */
 }

--- a/src/site/src/routes/+layout.ts
+++ b/src/site/src/routes/+layout.ts
@@ -1,0 +1,3 @@
+// since there's no dynamic data here, we can prerender
+// it so that it gets served as a static asset in production
+export const prerender = true;

--- a/src/site/svelte.config.js
+++ b/src/site/svelte.config.js
@@ -1,4 +1,4 @@
-import adapter from '@sveltejs/adapter-auto';
+import adapter from '@sveltejs/adapter-static';
 // import { vitePreprocess } from '@sveltejs/kit/vite';
 import preprocess from 'svelte-preprocess';
 
@@ -16,7 +16,7 @@ const config = {
 	],
 
 	kit: {
-		adapter: adapter()
+		adapter: adapter(),
 	}
 };
 


### PR DESCRIPTION
Closes #120 

With `npm run build` the prod version of the website is build. Then it's just a matter of grabbing the `build` folder and hosting it somewhere. It can be via GH pages or any other provider (TBD).