### PR TITLE
Update footer to link to rendered OTel spec instead of GH

### DIFF
--- a/src/site/src/lib/footer/Footer.svelte
+++ b/src/site/src/lib/footer/Footer.svelte
@@ -32,7 +32,7 @@
 								<li><a href="https://opentelemetry.io">Official website</a></li>
 								<li>
 									<a
-										href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/overview.md"
+										href="https://opentelemetry.io/docs/specs/otel/"
 									>
 										Specification
 									</a>


### PR DESCRIPTION
I assume most readers will prefer the rendered view with the tree navigator and table of contents, and for those that prefer to read it directly in the Github repo, the website provides a link to to that one as well.