### PR TITLE
Show all recipes by default

### DIFF
--- a/src/site/src/lib/_components/RecipeSteps.svelte
+++ b/src/site/src/lib/_components/RecipeSteps.svelte
@@ -1,13 +1,15 @@
 <script lang="ts">
 	import { fly } from 'svelte/transition';
 	import { Recipe, Recipes, Step } from '$lib/common/types';
-	import { resetSearch, selectedLanguage, selectedRecipe } from '$lib/store/store';
+	import { getLanguage, resetSearch, selectedRecipe } from '$lib/store/store';
 	import CodeStep from './CodeStep.svelte';
 	import MetadataStep from './MetadataStep.svelte';
 	import PackageInstallStep from './PackageInstallStep.svelte';
 	import { page } from '$app/stores';
 	import { goto } from '$app/navigation';
 	import { onDestroy } from 'svelte';
+
+	$: language = getLanguage($selectedRecipe.languageId);
 
 	const getSortedSteps = (steps: Step[]) => {
 		return steps.sort((left: Step, right: Step) => left.order - right.order);
@@ -56,7 +58,7 @@
 									<small class="icon">
 										<img class="icon-info" alt="info" src="info.svg" />
 									</small>
-									<MetadataStep sample={$selectedRecipe} language={$selectedLanguage} />
+									<MetadataStep sample={$selectedRecipe} language={language} />
 								</section>
 							</div>
 							<div class="step indicator">
@@ -68,18 +70,18 @@
 										<img class="icon-package" alt="package" src="package.svg" />
 									</small>
 									<img src="browser-buttons.svg" alt="browser top-bar icons" />
-									<PackageInstallStep sample={$selectedRecipe} language={$selectedLanguage} />
+									<PackageInstallStep sample={$selectedRecipe} language={language} />
 								</section>
 							</div>
 							{#each getSortedSteps($selectedRecipe.steps) as step}
 								<div class="step indicator">
 									<p class="step-language">
-										<span class="step-language-tag bd-is-html">{$selectedLanguage.id}</span>
+										<span class="step-language-tag bd-is-html">{language.id}</span>
 									</p>
 									<section>
 										<small class="icon">{step.order}</small>
 										<img src="browser-buttons.svg" alt="browser top-bar icons" />
-										<CodeStep {step} sample={$selectedRecipe} language={$selectedLanguage} />
+										<CodeStep {step} sample={$selectedRecipe} language={language} />
 									</section>
 								</div>
 							{/each}

--- a/src/site/src/lib/store/store.ts
+++ b/src/site/src/lib/store/store.ts
@@ -49,15 +49,15 @@ export const filteredSamples: Readable<Recipe[]> = derived(
 		// it's added again when the user selects a sample
 		// clearQueryParams();
 
+		let recipes: Recipe[] = $store;
+
 		if (
 			!$textSearch &&
 			$selectedLanguage.id === Languages.none.id &&
 			$selectedSignal.id === Signals.none.id
 		) {
-			return [];
+			return recipes.sort((a: Recipe, b: Recipe) => a.languageId.localeCompare(b.languageId));
 		}
-
-		let recipes: Recipe[] = $store;
 
 		// if there's any text, filter for it first.
 		if ($textSearch) {
@@ -90,15 +90,14 @@ export const selectedRecipe: Readable<Recipe> = derived(
 			return Recipes.none;
 		}
 
-		// When a sample is selected, make sure to also select the language and signal
-		// the filters are not all required for the search, but are required to display
-		// the sample metadata
-		selectedLanguage.set(Languages.all.find((l) => l.id === recipe.languageId));
-		selectedSignal.set(Signals.all.find((l) => l.id === recipe.signal));
-
 		return recipe;
 	}
 );
+
+export function getLanguage(languageId: string) {
+	let l = Languages.all.find((l) => l.id === languageId)
+	return l;
+}
 
 export function resetSearch() {
 	textSearch.set(null);

--- a/src/site/src/lib/store/store.ts
+++ b/src/site/src/lib/store/store.ts
@@ -95,8 +95,7 @@ export const selectedRecipe: Readable<Recipe> = derived(
 );
 
 export function getLanguage(languageId: string) {
-	let l = Languages.all.find((l) => l.id === languageId)
-	return l;
+	return Languages.all.find((l) => l.id === languageId)
 }
 
 export function resetSearch() {


### PR DESCRIPTION
Change the recipes page to display all recipes by default. I got feedback that the empty page is confusing and that it would make it easier to see the recipes when first arriving in the page.

Also fixed a bug where when selecting a recipe and pressing the browser back button, the language and signal dropdowns are populated even though the user never changed them. They were getting the lang/signal from the previously selected recipe sample.